### PR TITLE
Fix the version number of the language files for mozilla

### DIFF
--- a/templates/central/windows/de-DE/mozilla.adml
+++ b/templates/central/windows/de-DE/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/en-US/mozilla.adml
+++ b/templates/central/windows/en-US/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/es-ES/mozilla.adml
+++ b/templates/central/windows/es-ES/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/fr-FR/mozilla.adml
+++ b/templates/central/windows/fr-FR/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/it-IT/mozilla.adml
+++ b/templates/central/windows/it-IT/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/ru-RU/mozilla.adml
+++ b/templates/central/windows/ru-RU/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/zh-CN/mozilla.adml
+++ b/templates/central/windows/zh-CN/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>

--- a/templates/central/windows/zh-TW/mozilla.adml
+++ b/templates/central/windows/zh-TW/mozilla.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+<policyDefinitionResources revision="4.8" schemaVersion="1.0">
   <displayName/>
   <description/>
   <resources>


### PR DESCRIPTION
Hello,

in the language files for the `mozilla.admx` the revision is still set to `1.0`.
According to the `mozilla.admx` line 6 this must be at least `4.8`

Line 6: 
`<resources minRequiredRevision=‘4.8’ />`


According to the Firefox repo, `4.8` is also the current version, I have adjusted this accordingly.