### PR TITLE
Add InAppNotification documentation

### DIFF
--- a/docs/templates/release/README.md
+++ b/docs/templates/release/README.md
@@ -51,7 +51,7 @@ This document provides for all policies examples for the mentioned formats.
 | **[`ExtensionUpdate`](#extensionupdate)** | Control extension updates.
 | **[`Handlers`](#handlers)** | Configure default application handlers.
 | **[`HardwareAcceleration`](#hardwareacceleration)** | Control hardware acceleration.
-| **[`InAppNotification`](#inappnotification)** | TBD
+| **[`InAppNotification`](#inappnotification)** | Configure TOAST, browser, and tab notifications within the context of the application.
 | **[`InstallAddonsPermission`](#installaddonspermission)** | Configure the default extension install policy as well as origins for extension installs are allowed.
 | **[`ManualAppUpdateOnly`](#manualappupdateonly)** | Allow manual updates only and do not notify the user about updates.
 | **[`NetworkPrediction`](#networkprediction)** | Enable or disable network prediction (DNS prefetching).
@@ -2202,12 +2202,61 @@ Value (string):
 <br>
 
 ## InAppNotification
-TBD
+
+Configure TOAST, browser, and tab notifications within the context of the application.
+
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `mail.inappnotifications.donation_enabled`, `mail.inappnotifications.blog_enabled`, `mail.inappnotifications.message_enabled`, `mail.inappnotifications.enabled` 
+
+#### Windows (GPO)
+```
+Software\Policies\Mozilla\Thunderbird\InAppNotification_Enabled = 0x1 | 0x0
+Software\Policies\Mozilla\Thunderbird\InAppNotification_DonationEnabled = 0x1 | 0x0
+Software\Policies\Mozilla\Thunderbird\InAppNotification_SurveyEnabled = 0x1 | 0x0
+Software\Policies\Mozilla\Thunderbird\InAppNotification_MessageEnabled = 0x1 | 0x0
+```
+#### Windows (Intune)
+OMA-URI:
+```
+./Device/Vendor/MSFT/Policy/Config/Thunderbird~Policy~thunderbird/InAppNotification_Enabled
+./Device/Vendor/MSFT/Policy/Config/Thunderbird~Policy~thunderbird/InAppNotification_DonationEnabled
+./Device/Vendor/MSFT/Policy/Config/Thunderbird~Policy~thunderbird/InAppNotification_SurveyEnabled
+./Device/Vendor/MSFT/Policy/Config/Thunderbird~Policy~thunderbird/InAppNotification_MessageEnabled
+```
+Value (string):
+```
+<enabled/> or <disabled/>
+```
+#### macOS
+```
+<dict>
+  <key>InAppNotification_Enabled</key>
+  <enabled/> | <disabled/>
+  <key>InAppNotification_DonationEnabled</key>
+  <enabled/> | <disabled/>
+  <key>InAppNotification_SurveyEnabled</key>
+  <enabled/> | <disabled/>
+  <key>InAppNotification_MessageEnabled</key>
+  <enabled/> | <disabled/>
+</dict>
+```
+#### policies.json
+```
+{
+  "policies": {
+    "InAppNotification_Enabled": enabled | disabled,
+    "InAppNotification_DonationEnabled": enabled | disabled,
+    "InAppNotification_SurveyEnabled": enabled | disabled,
+    "InAppNotification_MessageEnabled": enabled | disabled
+  }
+}
+```
+
 #### Compatibility
 
 | Policy/Property Name | supported since | deprecated after |
 |:--- | ---:| ---:|
-| `InAppNotification`<br>`InAppNotification_DonationEnabled`<br>`InAppNotification_SurveyEnabled`<br>`InAppNotification_MessageEnabled`<br>`InAppNotification_Disabled` | 139.0 |  |
+| `InAppNotification_Enabled`<br>`InAppNotification_DonationEnabled`<br>`InAppNotification_SurveyEnabled`<br>`InAppNotification_MessageEnabled` | 139.0 |  |
 
 <br>
 

--- a/docs/templates/release/README.md
+++ b/docs/templates/release/README.md
@@ -2244,10 +2244,10 @@ Value (string):
 ```
 {
   "policies": {
-    "InAppNotification_Enabled": enabled | disabled,
-    "InAppNotification_DonationEnabled": enabled | disabled,
-    "InAppNotification_SurveyEnabled": enabled | disabled,
-    "InAppNotification_MessageEnabled": enabled | disabled
+    "InAppNotification_Enabled": true | false,
+    "InAppNotification_DonationEnabled": true | false,
+    "InAppNotification_SurveyEnabled": true | false,
+    "InAppNotification_MessageEnabled": true | false
   }
 }
 ```

--- a/generator/Readme.md
+++ b/generator/Readme.md
@@ -1,7 +1,7 @@
 update_policy_templates.js
 ==========================
 
-This script runs on the source trees `esr68`,`esr78`,`esr91`,`esr102`,`esr115` and `central`, and is doing the following for each:
+This script runs on the source trees `esr68`,`esr78`,`esr91`,`esr102`,`esr115`, `esr128` and `central`, and is doing the following for each:
 
 * Check for new revisions of the `policies-schema.json` file in `mozilla-${tree}` and report newly added policies, which Thunderbird might want to port.
 * Parse the `policies-schema.json` file in `comm-${tree}` to see what policies are supported by Thunderbird.

--- a/state/readme_central.json
+++ b/state/readme_central.json
@@ -186,7 +186,7 @@
       "upstream": "| **[`Homepage`](#homepage)** | Configure the default homepage and how Firefox starts."
     },
     "InAppNotification": {
-      "override": "| **[`InAppNotification`](#inappnotification)** | TBD"
+      "override": "| **[`InAppNotification`](#inappnotification)** | Configures push notifications"
     },
     "InstallAddonsPermission": {
       "upstream": "| **[`InstallAddonsPermission`](#installaddonspermission)** | Configure the default extension install policy as well as origins for extension installs are allowed."

--- a/state/readme_central.json
+++ b/state/readme_central.json
@@ -186,7 +186,7 @@
       "upstream": "| **[`Homepage`](#homepage)** | Configure the default homepage and how Firefox starts."
     },
     "InAppNotification": {
-      "override": "| **[`InAppNotification`](#inappnotification)** | Configures push notifications"
+      "override": "| **[`InAppNotification`](#inappnotification)** | Configure TOAST, browser, and tab notifications within the context of the application."
     },
     "InstallAddonsPermission": {
       "upstream": "| **[`InstallAddonsPermission`](#installaddonspermission)** | Configure the default extension install policy as well as origins for extension installs are allowed."


### PR DESCRIPTION
Added documentation for InAppNotifications.

I doubt the documentation is correct so I'll contact the services team to identify the correct paths, macos dict, policies.json file contents.